### PR TITLE
Fix dependencies for deploy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,7 +124,7 @@ line_length = 79
 
 [project.optional-dependencies]
 crf = [
-   "pydensecrf@git+https://github.com/lucasb-eyer/pydensecrf.git#egg=master",
+   # "pydensecrf@git+https://github.com/lucasb-eyer/pydensecrf.git#egg=master",
 ]
 pyqt5 = [
     "pyqt5",
@@ -164,7 +164,7 @@ test = [
     "coverage",
     "tox",
     "twine",
-    "pydensecrf@git+https://github.com/lucasb-eyer/pydensecrf.git#egg=master",
+    # "pydensecrf@git+https://github.com/lucasb-eyer/pydensecrf.git#egg=master",
     "onnx",
     "onnxruntime",
 ]


### PR DESCRIPTION
Disable optional dependency on pydense CRF.

Docs already mention how to install it correctly (i.e. via pip and not optional dep) so should not cause any issues to just comment it out. 