### PR TITLE
Additional fixes for py3.12: Fix Swin args, update docs workflow

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -1,39 +1,77 @@
-name: deploy
+name: docs
 
 on:
   push:
-    branches: # branch to trigger deployment
+    branches:
       - main
+    paths:
+      - "docs/**"
+      - "napari_cellseg3d/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/**"
+      - "napari_cellseg3d/**"
+      - "pyproject.toml"
+      - ".github/workflows/docs.yml"
+  workflow_dispatch:
 
-# This job installs dependencies, build the book, and pushes it to `gh-pages`
+permissions:
+  contents: read
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  build-and-deploy-book:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest]
-        python-version: [3.9]
+  build:
+    name: build docs
+    runs-on: ubuntu-latest
+
     steps:
-    - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v6
 
-    # Install dependencies
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
-      run: |
-        pip install jupyter-book
-        pip install -e .
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+          cache: pip
 
-    # Build the book
-    - name: Build the book
-      run: |
-        jupyter-book build docs/
+      - name: Install docs dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ".[docs]"
 
-    # Deploy the book's HTML to gh-pages branch
-    - name: GitHub Pages action
-      uses: peaceiris/actions-gh-pages@v3.6.1
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: docs/_build/html
+      - name: Build Jupyter Book
+        run: |
+          jupyter-book build docs/
+
+      - name: Upload Pages artifact
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/_build/html
+
+  deploy:
+    name: deploy docs
+    needs: build
+    runs-on: ubuntu-latest
+
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+
+    permissions:
+      pages: write
+      id-token: write
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/napari_cellseg3d/code_models/models/model_SwinUNetR.py
+++ b/napari_cellseg3d/code_models/models/model_SwinUNetR.py
@@ -53,9 +53,15 @@ class SwinUNETR_(SwinUNETR):
         try:
             parent_init(**init_kwargs)
         except TypeError as e:
-            logger.warning(f"Caught TypeError: {e}")
-            init_kwargs["in_channels"] = 1
-            parent_init(**init_kwargs)
+            if "img_size" in init_kwargs:
+                logger.warning(
+                    "Retrying SwinUNETR initialization without img_size due to "
+                    f"MONAI API compatibility issue: {e}"
+                )
+                init_kwargs.pop("img_size", None)
+                parent_init(**init_kwargs)
+            else:
+                raise
 
     # def forward(self, x_in):
     #     y = super().forward(x_in)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,7 +148,7 @@ dev = [
     "twine",
 ]
 docs = [
-    "jupyter-book",
+    "jupyter-book<2",
 ]
 test = [
     "pytest",


### PR DESCRIPTION
## Scope

- Fixes the outdated docs workflow
- Changes the guard for old MONAI SwinUNetR API

## Summary

This pull request updates the documentation build workflow and improves compatibility with dependencies in both the GitHub Actions workflow and the codebase. The main changes include a significant refactor of the documentation CI pipeline, a fix for SwinUNETR initialization to handle MONAI API changes, and a restriction on the `jupyter-book` version to avoid breaking changes.

**Documentation workflow improvements:**

* [`.github/workflows/build_docs.yml`](diffhunk://#diff-4dfe935b4852393622c2b414783d1d11e1a868fd8485709124d90208fa61ec8bL1-R77): Refactored the GitHub Actions workflow for building and deploying documentation. The workflow now triggers on pushes and pull requests affecting documentation-related files, splits the build and deploy steps, adds concurrency controls, and uses the latest actions and Python 3.12. Deployment is handled with the official `actions/deploy-pages` action.

**Dependency compatibility:**

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L151-R151): Restricted the `jupyter-book` dependency to versions below 2 to prevent incompatibility issues with breaking changes in newer versions.

**Model initialization robustness:**

* [`napari_cellseg3d/code_models/models/model_SwinUNetR.py`](diffhunk://#diff-4b6939b806799c93d33e80a6f6cfaa8fd719602f190d92899d6799c3f536c95fL56-R64): Improved the SwinUNETR model initialization logic to retry without the `img_size` parameter if a `TypeError` occurs, addressing MONAI API compatibility issues.