### PR TITLE
Update README & docs CI for Python 3.12 support

### DIFF
--- a/.napari/DESCRIPTION.md
+++ b/.napari/DESCRIPTION.md
@@ -98,7 +98,7 @@ more detailed documentation if you have it.
 
 ## Additional Install Steps
 
-**Python >= 3.8 required**
+**Python >= 3.10 required**
 
 Requires manual installation of **pytorch** and **MONAI**.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@
 [![codecov](https://codecov.io/gh/AdaptiveMotorControlLab/CellSeg3D/branch/main/graph/badge.svg?token=hzUcn3XN8F)](https://codecov.io/gh/AdaptiveMotorControlLab/CellSeg3D)
 [![Code style:Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
 
-
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/838605d0-9723-4e43-83cd-6dbfe4adf36b/cellseg-logo.png?format=1500w" title="cellseg3d" alt="cellseg3d logo" width="150" align="right" vspace = "80"/>
 
 **A package for 3D cell segmentation with deep learning, including a napari plugin**: training, inference, and data review. In particular, this project was developed for analysis of confocal and mesoSPIM-acquired (cleared tissue + lightsheet) tissue datasets, but is not limited to this type of data. [Check out our publication for more information!](https://elifesciences.org/articles/99848)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,13 @@
 <!-- [![napari hub](https://img.shields.io/endpoint?url=https://api.napari-hub.org/shields/napari-cellseg3d)](https://www.napari-hub.org/plugins/napari_cellseg3d) -->
 
 [![PyPI](https://img.shields.io/pypi/v/napari-cellseg3d.svg?color=green)](https://pypi.org/project/napari-cellseg3d)
+[![Python versions](https://img.shields.io/pypi/pyversions/napari-cellseg3d)](https://pypi.org/project/napari-cellseg3d)
 [![Downloads](https://static.pepy.tech/badge/napari-cellseg3d)](https://pepy.tech/project/napari-cellseg3d)
 [![Downloads](https://static.pepy.tech/badge/napari-cellseg3d/month)](https://pepy.tech/project/napari-cellseg3d)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://github.com/AdaptiveMotorControlLab/CellSeg3D/raw/main/LICENSE)
 [![codecov](https://codecov.io/gh/AdaptiveMotorControlLab/CellSeg3D/branch/main/graph/badge.svg?token=hzUcn3XN8F)](https://codecov.io/gh/AdaptiveMotorControlLab/CellSeg3D)
-<a href="https://github.com/psf/black"><img alt="Code style: black" src="https://img.shields.io/badge/code%20style-black-000000.svg"></a>
+[![Code style:Ruff](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json)](https://github.com/astral-sh/ruff)
+
 
 <img src="https://images.squarespace-cdn.com/content/v1/57f6d51c9f74566f55ecf271/838605d0-9723-4e43-83cd-6dbfe4adf36b/cellseg-logo.png?format=1500w" title="cellseg3d" alt="cellseg3d logo" width="150" align="right" vspace = "80"/>
 
@@ -65,7 +67,16 @@ F1-score is computed from the Intersection over Union (IoU) with ground truth la
 
 Read the [article here !](https://elifesciences.org/articles/99848)
 
-### **New version: v0.2.2**
+### **New version: v0.2.3**
+
+- v0.2.3:
+  - Python 3.10-12 support added
+  - Several fixes to deprecation errors on newer Python versions
+  - Upgraded packaging to use only pyproject.toml
+  - Added uv.lock to repository for more reproducible installs
+
+> [!WARNING]
+> If you are still getting errors related to `in_channels` on the SwinUNetR model, please open an issue and report your MONAI version. Thanks!
 
 - v0.2.2:
 
@@ -102,7 +113,7 @@ Previous additions:
 
 ## Requirements
 
-**Compatible with Python 3.8 to 3.10.**
+**Compatible with Python 3.10 to 3.12.**
 Requires **[napari]**, **[PyTorch]** and **[MONAI]**.
 Compatible with Windows, MacOS and Linux.
 Installation of the plugin itself should not take more than 30 minutes, depending on your internet connection,

--- a/napari_cellseg3d/code_models/models/model_SwinUNetR.py
+++ b/napari_cellseg3d/code_models/models/model_SwinUNetR.py
@@ -45,7 +45,6 @@ class SwinUNETR_(SwinUNETR):
             **kwargs,
         )
         if "img_size" in sig.parameters:
-            # since MONAI API changes depending on py3.8 or py3.9
             init_kwargs["img_size"] = input_img_size
         if "dropout_prob" in kwargs:
             init_kwargs["drop_rate"] = kwargs["dropout_prob"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,164 +1,148 @@
-[project]
-name = "napari_cellseg3d"
-authors = [
-    {name = "Cyril Achard", email = "cyril.achard@epfl.ch"},
-    {name = "Maxime Vidal", email = "maxime.vidal@epfl.ch"},
-    {name = "Mackenzie Mathis", email = "mackenzie@post.harvard.edu"},
-]
-readme = "README.md"
-description = "Plugin for cell segmentation in 3D"
-classifiers = [
-    "Development Status :: 4 - Beta",
-    "Intended Audience :: Science/Research",
-    "Framework :: napari",
-    "Topic :: Software Development :: Testing",
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "Operating System :: OS Independent",
-    "License :: OSI Approved :: MIT License",
-    "Topic :: Scientific/Engineering :: Artificial Intelligence",
-    "Topic :: Scientific/Engineering :: Image Processing",
-    "Topic :: Scientific/Engineering :: Visualization",
-]
-license = {text = "MIT"}
-requires-python = ">=3.10"
-dependencies = [
-    "numpy",
-    "napari[all]>=0.4.14",
-    "QtPy",
-#    "opencv-python>=4.5.5",
-#    "dask-image>=0.6.0",
-    "scikit-image>=0.19.2",
-    "matplotlib>=3.4.1",
-#    "tifffile>=2022.2.9",
-#    "imageio-ffmpeg>=0.4.5",
-    "imagecodecs>=2023.3.16",
-    "torch>=1.11",
-    "monai[nibabel,einops, tifffile]>=0.9.0",
-    "itk",
-    "tqdm",
-#    "nibabel",
-#    "pillow",
-    "pyclesperanto",
-    "pydensecrf2",
-]
-dynamic = ["version"]
-
-[project.urls]
-Homepage  = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
-Documentation = "https://adaptivemotorcontrollab.github.io/cellseg3d-docs/res/welcome.html"
-Issues = "https://github.com/AdaptiveMotorControlLab/CellSeg3D/issues"
-
-[project.entry-points."napari.manifest"]
-"napari_cellseg3d" = "napari_cellseg3d:napari.yaml"
-
 [build-system]
-requires = [
-    "setuptools>=64",
-    "setuptools-scm>=8",
-    "wheel",
-]
 build-backend = "setuptools.build_meta"
+requires = [
+  "setuptools>=64",
+  "setuptools-scm>=8",
+  "wheel",
+]
+
+[project]
+name = "napari-cellseg3d"
+description = "Plugin for cell segmentation in 3D"
+readme = "README.md"
+license = { text = "MIT" }
+authors = [
+  { name = "Cyril Achard", email = "cyril.achard@epfl.ch" },
+  { name = "Maxime Vidal", email = "maxime.vidal@epfl.ch" },
+  { name = "Mackenzie Mathis", email = "mackenzie@post.harvard.edu" },
+]
+requires-python = ">=3.10"
+classifiers = [
+  "Development Status :: 4 - Beta",
+  "Framework :: napari",
+  "Intended Audience :: Science/Research",
+  "License :: OSI Approved :: MIT License",
+  "Operating System :: OS Independent",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Artificial Intelligence",
+  "Topic :: Scientific/Engineering :: Image Processing",
+  "Topic :: Scientific/Engineering :: Visualization",
+  "Topic :: Software Development :: Testing",
+]
+dynamic = [ "version" ]
+dependencies = [
+  # "tifffile>=2022.2.9",
+  #    "imageio-ffmpeg>=0.4.5",
+  "imagecodecs>=2023.3.16",
+  "itk",
+  "matplotlib>=3.4.1",
+  "monai[einops,nibabel,tifffile]>=0.9",
+  "napari[all]>=0.4.14",
+  "numpy",
+  # "nibabel",
+  #    "pillow",
+  "pyclesperanto",
+  "pydensecrf2",
+  "qtpy",
+  # "opencv-python>=4.5.5",
+  #    "dask-image>=0.6.0",
+  "scikit-image>=0.19.2",
+  "torch>=1.11",
+  "tqdm",
+]
+optional-dependencies.crf = [
+  "pydensecrf2",
+]
+optional-dependencies.dev = [
+  "pre-commit",
+  "ruff",
+  "twine",
+]
+optional-dependencies.docs = [
+  "jupyter-book<2",
+]
+optional-dependencies.onnx-cpu = [ "onnx", "onnxruntime" ]
+optional-dependencies.onnx-gpu = [ "onnx", "onnxruntime-gpu" ]
+optional-dependencies.pyqt6 = [
+  "napari[pyqt6]",
+]
+optional-dependencies.pyside6 = [
+  "napari[pyside6]",
+]
+optional-dependencies.test = [
+  "coverage",
+  "onnx",
+  "onnxruntime",
+  "pytest",
+  "pytest-cov",
+  "pytest-qt",
+  "tox",
+  "twine",
+]
+optional-dependencies.wandb = [ "wandb" ]
+urls.Documentation = "https://adaptivemotorcontrollab.github.io/cellseg3d-docs/res/welcome.html"
+urls.Homepage = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
+urls.Issues = "https://github.com/AdaptiveMotorControlLab/CellSeg3D/issues"
+entry-points."napari.manifest".napari_cellseg3d = "napari_cellseg3d:napari.yaml"
 
 [tool.setuptools]
 include-package-data = true
+package-data."*" = [ "res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml" ]
+packages.find.where = [ "." ]
 
 [tool.setuptools_scm]
 version_file = "napari_cellseg3d/_version.py"
 
-[tool.setuptools.packages.find]
-where = ["."]
-
-[tool.setuptools.package-data]
-"*" = ["res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml"]
-
 [tool.ruff]
-select = [
-    "E", "F", "W",
-    "A",
-    "B",
-    "D",
-    "G",
-    "I",
-    "PT",
-    "PTH",
-    "RET",
-    "SIM",
-    "NPY",
+exclude = [
+  ".bzr",
+  ".direnv",
+  ".eggs",
+  ".git",
+  ".git-rewrite",
+  ".hg",
+  ".mypy_cache",
+  ".nox",
+  ".pants.d",
+  ".pytype",
+  ".ruff_cache",
+  ".svn",
+  ".tox",
+  ".venv",
+  "__pypackages__",
+  "_build",
+  "buck-out",
+  "build",
+  "dist",
+  "docs/conf.py",
+  "napari_cellseg3d/_tests/conftest.py",
+  "node_modules",
+  "venv",
 ]
 # Never enforce `E501` (line length violations) and 'E741' (ambiguous variable names)
 # and 'G004' (do not use f-strings in logging)
 # and 'A003' (Shadowing python builtins)
 # and 'F401' (imported but unused)
-ignore = ["E501", "E741", "G004", "A003", "F401"]
-exclude = [
-    ".bzr",
-    ".direnv",
-    ".eggs",
-    ".git",
-    ".git-rewrite",
-    ".hg",
-    ".mypy_cache",
-    ".nox",
-    ".pants.d",
-    ".pytype",
-    ".ruff_cache",
-    ".svn",
-    ".tox",
-    ".venv",
-    "__pypackages__",
-    "_build",
-    "buck-out",
-    "build",
-    "dist",
-    "node_modules",
-    "venv",
-    "docs/conf.py",
-    "napari_cellseg3d/_tests/conftest.py",
-]
-
-[tool.ruff.pydocstyle]
-convention = "google"
-
-[project.optional-dependencies]
-pyside6 = [
-    "napari[pyside6]",
-]
-pyqt6 = [
-    "napari[pyqt6]",
-]
-onnx-cpu = [
-    "onnx",
-    "onnxruntime"
-]
-onnx-gpu = [
-    "onnx",
-    "onnxruntime-gpu"
-]
-wandb = [
-    "wandb"
-]
-dev = [
-    "ruff",
-    "pre-commit",
-    "twine",
-]
-docs = [
-    "jupyter-book<2",
-]
-test = [
-    "pytest",
-    "pytest-qt",
-    "pytest-cov",
-    "coverage",
-    "tox",
-    "twine",
-    "onnx",
-    "onnxruntime",
-]
-crf = [
-    "pydensecrf2",
+ignore = [ "E501", "E741", "G004", "A003", "F401" ]
+pydocstyle.convention = "google"
+select = [
+  "E",
+  "F",
+  "W",
+  "A",
+  "B",
+  "D",
+  "G",
+  "I",
+  "PT",
+  "PTH",
+  "RET",
+  "SIM",
+  "NPY",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,163 +1,164 @@
-[build-system]
-build-backend = "setuptools.build_meta"
-requires = [
-  "setuptools>=64",
-  "setuptools-scm>=8",
-  "wheel",
-]
-
 [project]
-name = "napari-cellseg3d"
-description = "Plugin for cell segmentation in 3D"
+name = "napari_cellseg3d"
+authors = [
+    {name = "Cyril Achard", email = "cyril.achard@epfl.ch"},
+    {name = "Maxime Vidal", email = "maxime.vidal@epfl.ch"},
+    {name = "Mackenzie Mathis", email = "mackenzie@post.harvard.edu"},
+]
 readme = "README.md"
-license = { text = "MIT" }
-requires-python = ">=3.10"
+description = "Plugin for cell segmentation in 3D"
 classifiers = [
-  "Development Status :: 4 - Beta",
-  "Framework :: napari",
-  "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: MIT License",
-  "Operating System :: OS Independent",
-  "Programming Language :: Python",
-  "Programming Language :: Python :: 3 :: Only",
-  "Programming Language :: Python :: 3.10",
-  "Programming Language :: Python :: 3.11",
-  "Programming Language :: Python :: 3.12",
-  "Topic :: Scientific/Engineering :: Artificial Intelligence",
-  "Topic :: Scientific/Engineering :: Image Processing",
-  "Topic :: Scientific/Engineering :: Visualization",
-  "Topic :: Software Development :: Testing",
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Science/Research",
+    "Framework :: napari",
+    "Topic :: Software Development :: Testing",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Operating System :: OS Independent",
+    "License :: OSI Approved :: MIT License",
+    "Topic :: Scientific/Engineering :: Artificial Intelligence",
+    "Topic :: Scientific/Engineering :: Image Processing",
+    "Topic :: Scientific/Engineering :: Visualization",
 ]
-dynamic = [ "version" ]
+license = {text = "MIT"}
+requires-python = ">=3.10"
 dependencies = [
-  # "tifffile>=2022.2.9",
-  #    "imageio-ffmpeg>=0.4.5",
-  "imagecodecs>=2023.3.16",
-  "itk",
-  "matplotlib>=3.4.1",
-  "monai[einops,nibabel,tifffile]>=0.9",
-  "napari[all]>=0.4.14",
-  "numpy",
-  # "nibabel",
-  #    "pillow",
-  "pyclesperanto",
-  "pydensecrf2",
-  "qtpy",
-  # "opencv-python>=4.5.5",
-  #    "dask-image>=0.6.0",
-  "scikit-image>=0.19.2",
-  "torch>=1.11",
-  "tqdm",
+    "numpy",
+    "napari[all]>=0.4.14",
+    "QtPy",
+#    "opencv-python>=4.5.5",
+#    "dask-image>=0.6.0",
+    "scikit-image>=0.19.2",
+    "matplotlib>=3.4.1",
+#    "tifffile>=2022.2.9",
+#    "imageio-ffmpeg>=0.4.5",
+    "imagecodecs>=2023.3.16",
+    "torch>=1.11",
+    "monai[nibabel,einops, tifffile]>=0.9.0",
+    "itk",
+    "tqdm",
+#    "nibabel",
+#    "pillow",
+    "pyclesperanto",
+    "pydensecrf2",
 ]
-[[project.authors]]
-name = "Cyril Achard"
-email = "cyril.achard@epfl.ch"
-[[project.authors]]
-name = "Maxime Vidal"
-email = "maxime.vidal@epfl.ch"
-[[project.authors]]
-name = "Mackenzie Mathis"
-email = "mackenzie@post.harvard.edu"
-[project.entry-points]
-"napari.manifest".napari_cellseg3d = "napari_cellseg3d:napari.yaml"
-[project.optional-dependencies]
-crf = [
-  "pydensecrf2",
-]
-dev = [
-  "pre-commit",
-  "ruff",
-  "twine",
-]
-docs = [
-  "jupyter-book",
-]
-onnx-cpu = [ "onnx", "onnxruntime" ]
-onnx-gpu = [ "onnx", "onnxruntime-gpu" ]
-pyqt6 = [
-  "napari[pyqt6]",
-]
-pyside6 = [
-  "napari[pyside6]",
-]
-test = [
-  "coverage",
-  "onnx",
-  "onnxruntime",
-  "pytest",
-  "pytest-cov",
-  "pytest-qt",
-  "tox",
-  "twine",
-]
-wandb = [ "wandb" ]
+dynamic = ["version"]
+
 [project.urls]
+Homepage  = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
 Documentation = "https://adaptivemotorcontrollab.github.io/cellseg3d-docs/res/welcome.html"
-Homepage = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
 Issues = "https://github.com/AdaptiveMotorControlLab/CellSeg3D/issues"
+
+[project.entry-points."napari.manifest"]
+"napari_cellseg3d" = "napari_cellseg3d:napari.yaml"
+
+[build-system]
+requires = [
+    "setuptools>=64",
+    "setuptools-scm>=8",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 include-package-data = true
-[tool.setuptools.package-data]
-"*" = [ "res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml" ]
-[tool.setuptools.packages]
-find.where = [ "." ]
 
 [tool.setuptools_scm]
 version_file = "napari_cellseg3d/_version.py"
 
+[tool.setuptools.packages.find]
+where = ["."]
+
+[tool.setuptools.package-data]
+"*" = ["res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml"]
+
 [tool.ruff]
-exclude = [
-  ".bzr",
-  ".direnv",
-  ".eggs",
-  ".git",
-  ".git-rewrite",
-  ".hg",
-  ".mypy_cache",
-  ".nox",
-  ".pants.d",
-  ".pytype",
-  ".ruff_cache",
-  ".svn",
-  ".tox",
-  ".venv",
-  "__pypackages__",
-  "_build",
-  "buck-out",
-  "build",
-  "dist",
-  "docs/conf.py",
-  "napari_cellseg3d/_tests/conftest.py",
-  "node_modules",
-  "venv",
-]
-[tool.ruff.lint]
 select = [
-  "E",
-  "F",
-  "W",
-  "A",
-  "B",
-  "G",
-  "I",
-  "PT",
-  "PTH",
-  "RET",
-  "SIM",
-  "NPY",
+    "E", "F", "W",
+    "A",
+    "B",
+    "D",
+    "G",
+    "I",
+    "PT",
+    "PTH",
+    "RET",
+    "SIM",
+    "NPY",
 ]
 # Never enforce `E501` (line length violations) and 'E741' (ambiguous variable names)
 # and 'G004' (do not use f-strings in logging)
 # and 'A003' (Shadowing python builtins)
 # and 'F401' (imported but unused)
-# and 'E402' (module level import not at top of file)
-ignore = [ "E501", "E741", "G004", "A003", "F401", "E402" ]
-[tool.ruff.lint.pydocstyle]
+ignore = ["E501", "E741", "G004", "A003", "F401"]
+exclude = [
+    ".bzr",
+    ".direnv",
+    ".eggs",
+    ".git",
+    ".git-rewrite",
+    ".hg",
+    ".mypy_cache",
+    ".nox",
+    ".pants.d",
+    ".pytype",
+    ".ruff_cache",
+    ".svn",
+    ".tox",
+    ".venv",
+    "__pypackages__",
+    "_build",
+    "buck-out",
+    "build",
+    "dist",
+    "node_modules",
+    "venv",
+    "docs/conf.py",
+    "napari_cellseg3d/_tests/conftest.py",
+]
+
+[tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.pyproject-fmt]
-max_supported_python = "3.12"
-generate_python_version_classifiers = true
-# Avoid collapsing tables to field.key = value format (less readable)
-table_format = "long"
+[project.optional-dependencies]
+pyside6 = [
+    "napari[pyside6]",
+]
+pyqt6 = [
+    "napari[pyqt6]",
+]
+onnx-cpu = [
+    "onnx",
+    "onnxruntime"
+]
+onnx-gpu = [
+    "onnx",
+    "onnxruntime-gpu"
+]
+wandb = [
+    "wandb"
+]
+dev = [
+    "ruff",
+    "pre-commit",
+    "twine",
+]
+docs = [
+    "jupyter-book<2",
+]
+test = [
+    "pytest",
+    "pytest-qt",
+    "pytest-cov",
+    "coverage",
+    "tox",
+    "twine",
+    "onnx",
+    "onnxruntime",
+]
+crf = [
+    "pydensecrf2",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,11 +11,6 @@ name = "napari-cellseg3d"
 description = "Plugin for cell segmentation in 3D"
 readme = "README.md"
 license = { text = "MIT" }
-authors = [
-  { name = "Cyril Achard", email = "cyril.achard@epfl.ch" },
-  { name = "Maxime Vidal", email = "maxime.vidal@epfl.ch" },
-  { name = "Mackenzie Mathis", email = "mackenzie@post.harvard.edu" },
-]
 requires-python = ">=3.10"
 classifiers = [
   "Development Status :: 4 - Beta",
@@ -28,8 +23,6 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13",
-  "Programming Language :: Python :: 3.14",
   "Topic :: Scientific/Engineering :: Artificial Intelligence",
   "Topic :: Scientific/Engineering :: Image Processing",
   "Topic :: Scientific/Engineering :: Visualization",
@@ -56,26 +49,38 @@ dependencies = [
   "torch>=1.11",
   "tqdm",
 ]
-optional-dependencies.crf = [
+[[project.authors]]
+name = "Cyril Achard"
+email = "cyril.achard@epfl.ch"
+[[project.authors]]
+name = "Maxime Vidal"
+email = "maxime.vidal@epfl.ch"
+[[project.authors]]
+name = "Mackenzie Mathis"
+email = "mackenzie@post.harvard.edu"
+[project.entry-points]
+"napari.manifest".napari_cellseg3d = "napari_cellseg3d:napari.yaml"
+[project.optional-dependencies]
+crf = [
   "pydensecrf2",
 ]
-optional-dependencies.dev = [
+dev = [
   "pre-commit",
   "ruff",
   "twine",
 ]
-optional-dependencies.docs = [
+docs = [
   "jupyter-book<2",
 ]
-optional-dependencies.onnx-cpu = [ "onnx", "onnxruntime" ]
-optional-dependencies.onnx-gpu = [ "onnx", "onnxruntime-gpu" ]
-optional-dependencies.pyqt6 = [
+onnx-cpu = [ "onnx", "onnxruntime" ]
+onnx-gpu = [ "onnx", "onnxruntime-gpu" ]
+pyqt6 = [
   "napari[pyqt6]",
 ]
-optional-dependencies.pyside6 = [
+pyside6 = [
   "napari[pyside6]",
 ]
-optional-dependencies.test = [
+test = [
   "coverage",
   "onnx",
   "onnxruntime",
@@ -85,16 +90,18 @@ optional-dependencies.test = [
   "tox",
   "twine",
 ]
-optional-dependencies.wandb = [ "wandb" ]
-urls.Documentation = "https://adaptivemotorcontrollab.github.io/cellseg3d-docs/res/welcome.html"
-urls.Homepage = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
-urls.Issues = "https://github.com/AdaptiveMotorControlLab/CellSeg3D/issues"
-entry-points."napari.manifest".napari_cellseg3d = "napari_cellseg3d:napari.yaml"
+wandb = [ "wandb" ]
+[project.urls]
+Documentation = "https://adaptivemotorcontrollab.github.io/cellseg3d-docs/res/welcome.html"
+Homepage = "https://github.com/AdaptiveMotorControlLab/CellSeg3D"
+Issues = "https://github.com/AdaptiveMotorControlLab/CellSeg3D/issues"
 
 [tool.setuptools]
 include-package-data = true
-package-data."*" = [ "res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml" ]
-packages.find.where = [ "." ]
+[tool.setuptools.package-data]
+"*" = [ "res/*.png", "code_models/models/pretrained/*.json", "*.yaml", "napari.yaml" ]
+[tool.setuptools.packages]
+find.where = [ "." ]
 
 [tool.setuptools_scm]
 version_file = "napari_cellseg3d/_version.py"
@@ -125,19 +132,13 @@ exclude = [
   "node_modules",
   "venv",
 ]
-# Never enforce `E501` (line length violations) and 'E741' (ambiguous variable names)
-# and 'G004' (do not use f-strings in logging)
-# and 'A003' (Shadowing python builtins)
-# and 'F401' (imported but unused)
-ignore = [ "E501", "E741", "G004", "A003", "F401" ]
-pydocstyle.convention = "google"
+[tool.ruff.lint]
 select = [
   "E",
   "F",
   "W",
   "A",
   "B",
-  "D",
   "G",
   "I",
   "PT",
@@ -146,3 +147,17 @@ select = [
   "SIM",
   "NPY",
 ]
+# Never enforce `E501` (line length violations) and 'E741' (ambiguous variable names)
+# and 'G004' (do not use f-strings in logging)
+# and 'A003' (Shadowing python builtins)
+# and 'F401' (imported but unused)
+# and 'E402' (module level import not at top of file)
+ignore = [ "E501", "E741", "G004", "A003", "F401", "E402" ]
+[tool.ruff.lint.pydocstyle]
+convention = "google"
+
+[tool.pyproject-fmt]
+max_supported_python = "3.12"
+generate_python_version_classifiers = true
+# Avoid collapsing tables to field.key = value format (less readable)
+table_format = "long"


### PR DESCRIPTION
This pull request updates the documentation and compatibility for the project to support Python 3.10 through 3.12, and addresses several deprecation issues for newer Python versions. 
It also updates the README with new badges and version information, and fixes the lost jupyter-book version pin for CI.

**Python version compatibility updates:**
* Updated documentation to require Python 3.10 or higher in docs (`.napari/DESCRIPTION.md`, `README.md`). [[1]](diffhunk://#diff-d51069cc259ebfb5159d8fcb83f1b13e073d5b072506dff4ac1e780f27ea2c12L96-R96) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R114)
* Officially added support for Python 3.10–3.12, and removed references to Python 3.8 and 3.9 (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R80) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L103-R114)

**Documentation and packaging improvements:**
* Updated the README to show the new version (v0.2.3), added a Python version badge, replaced the Black code style badge with Ruff, and documented the addition of `uv.lock` for reproducible installs (`README.md`). [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R4-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L69-R80)
* Noted several fixes for deprecation errors on newer Python versions in the changelog (`README.md`).

**Code maintenance:**
* Removed outdated comments about MONAI API differences for Python 3.8/3.9 in `model_SwinUNetR.py`, reflecting the dropped support for older Python versions.